### PR TITLE
Don't abort when format-on-save's working directory is gone

### DIFF
--- a/Frameworks/OakTextView/src/OakTextView+Formatting.mm
+++ b/Frameworks/OakTextView/src/OakTextView+Formatting.mm
@@ -23,11 +23,19 @@ static NSString* runCustomFormatter (std::string const& command, NSString* input
 
 	task.environment = env;
 
+	// A stale project path (deleted directory) must not abort the app:
+	// -[NSTask launch] raises when the working directory does not exist, and
+	// TextMate's NSExceptionHandler escalates that to abort before @catch.
 	auto it = variables.find("TM_PROJECT_DIRECTORY");
 	if(it == variables.end())
 		it = variables.find("TM_DIRECTORY");
 	if(it != variables.end())
-		task.currentDirectoryURL = [NSURL fileURLWithPath:[NSString stringWithCxxString:it->second]];
+	{
+		BOOL isDirectory = NO;
+		NSString* directory = [NSString stringWithCxxString:it->second];
+		if([NSFileManager.defaultManager fileExistsAtPath:directory isDirectory:&isDirectory] && isDirectory)
+			task.currentDirectoryURL = [NSURL fileURLWithPath:directory];
+	}
 
 	NSPipe* stdinPipe  = [NSPipe pipe];
 	NSPipe* stdoutPipe = [NSPipe pipe];


### PR DESCRIPTION
`-[NSTask launch]` raises `NSInvalidArgumentException` when the task's working directory does not exist, and the `NSExceptionHandler` setup escalates the raise to `abort()` before the surrounding `@catch` can run.

A window's `projectPath` is sticky — it is seeded from the first pathed document the window shows and can outlive the directory it points to. Observed as a hard crash on save: a temporary directory seeded a scratch window's project path, the directory was later deleted, and the next format-on-save aborted the app.

Fix: only set the task's working directory when it actually exists (one guard in `OakTextView+Formatting.mm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)